### PR TITLE
New report_object_type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.2.1 (2017-07-07)
+
+- Updated generate_field_data to support new report object type
+
 # 0.2.0 (2017-06-21)
 
 - Updated update-lvm.sh and generate_field_data for the new Git repo containing the LVM2 project

--- a/bin/generate_field_data
+++ b/bin/generate_field_data
@@ -132,7 +132,7 @@ File.readlines(lvm_source + COLUMNS_FILE).each do |line|
   # dropped when passing column names as arguments as well, but i found a few
   # with issues (seg_start).
   case app
-  when "LVS", "LVSINFOSTATUS"
+  when "LVS", "LVSINFOSTATUS", "LVSSTATUS"
     method.sub!(%r{^lv_}, "")
   when "SEGS"
     method.sub!(%r{^seg_}, "")
@@ -154,7 +154,7 @@ File.readlines(lvm_source + COLUMNS_FILE).each do |line|
   }
 
   case app
-  when "LVS", "LVSINFOSTATUS"
+  when "LVS", "LVSINFOSTATUS", "LVSSTATUS"
     lvs << attribute
   when "SEGS"
     lvssegs << attribute


### PR DESCRIPTION
Hi,

 For sometime I found that https://github.com/sensu-plugins/sensu-plugins-lvm Sensu plugin stopped to work.
 It looks like that lvs.yaml was missing some attributes, which was not removed by ustream (LVM2), but upstream introduced new report_object_type (LVSSTATUS).
 Commit fix'es update generate_field_data script to add again all fields.

Aivaras