### PR TITLE
Update the updater script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,11 @@
 # 0.2.6 (2018-11-02)
 
-- Added attributes 2.02.178(2) to 2.02.182(2)
+- Added attributes for 2.02.178(2), 2.02.178(2)-rc1, 2.02.179(2), 2.02.180(2), 2.02.181(2), 2.02.182(2)
 - Reworked the tooling to generate the attributes to work with the new format
 
 # 0.2.5 (2018-11-01)
 
-- Added v2_02_180 attributes
+- This release is broken and has no changes.
 
 # 0.2.4 (2018-06-29)
 

--- a/bin/generate_field_data
+++ b/bin/generate_field_data
@@ -199,7 +199,8 @@ pvs.sort!     { |x, y| x[:column] <=> y[:column] }
 pvssegs.sort! { |x, y| x[:column] <=> y[:column] }
 vgs.sort!     { |x, y| x[:column] <=> y[:column] }
 
-FileUtils.mkdir(version)
+attributes_dir = "lib/lvm/attributes/#{version}"
+FileUtils.mkdir(attributes_dir)
 
 disclaimer = <<go
 # These are column to object attribute mappings
@@ -207,10 +208,10 @@ disclaimer = <<go
 # #{lvm_source}/lib/report/columns.h
 go
 
-File.open("#{version}/lvs.yaml", "w")    { |f| f.write(disclaimer); f.write(lvs.to_yaml) }
-File.open("#{version}/lvsseg.yaml", "w") { |f| f.write(disclaimer); f.write(lvssegs.to_yaml) }
-File.open("#{version}/pvs.yaml", "w")    { |f| f.write(disclaimer); f.write(pvs.to_yaml) }
-File.open("#{version}/pvsseg.yaml", "w") { |f| f.write(disclaimer); f.write(pvssegs.to_yaml) }
-File.open("#{version}/vgs.yaml", "w")    { |f| f.write(disclaimer); f.write(vgs.to_yaml) }
+File.open("#{attributes_dir}/lvs.yaml", "w")    { |f| f.write(disclaimer); f.write(lvs.to_yaml) }
+File.open("#{attributes_dir}/lvsseg.yaml", "w") { |f| f.write(disclaimer); f.write(lvssegs.to_yaml) }
+File.open("#{attributes_dir}/pvs.yaml", "w")    { |f| f.write(disclaimer); f.write(pvs.to_yaml) }
+File.open("#{attributes_dir}/pvsseg.yaml", "w") { |f| f.write(disclaimer); f.write(pvssegs.to_yaml) }
+File.open("#{attributes_dir}/vgs.yaml", "w")    { |f| f.write(disclaimer); f.write(vgs.to_yaml) }
 
 puts "Done."

--- a/update-lvm.sh
+++ b/update-lvm.sh
@@ -97,7 +97,7 @@ Added $tag attributes
 
 $(git diff --stat HEAD $attr_dir)
 EOF
-	git commit -F .git/commit-msg $attr_dir
+	git commit -s -F .git/commit-msg $attr_dir
 
 	return 0
 }


### PR DESCRIPTION
### Description

recent updates (efb892b) made the logic broken. it would no longer catch updates because submodule pointer is never updated.

also made some other fixes:
- fix changelog to note actual changes
- generate directly to real path needed
- include diffstat to commit message
- creates signed commits
- cleaned up from the `next` branch being no longer used
- switches lvm2 remote to master

### Check List

- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
